### PR TITLE
Add basic context menu support for Linux (KDE dolphin)

### DIFF
--- a/FEATURE_SET.md
+++ b/FEATURE_SET.md
@@ -13,6 +13,7 @@
     - [Text files (json, yaml, ini, etc)](#text-files-json-yaml-ini-etc)
     - [Hash files (sha256, md5, etc)](#hash-files-sha256-md5-etc)
     - [Windows utilities](#windows-utilities)
+    - [Linux utilities](#linux-utilities)
     - [App configuration](#app-configuration)
     - [Processing pipelines](#processing-pipelines)
 
@@ -124,6 +125,14 @@
 | win uninstall-menu   | Uninstalls app context menu (right click in Windows Explorer) | No input files | No output files |
 | win restart-explorer | Restarts explorer.exe                                         | No input files | No output files |
 
+
+### Linux utilities
+
+
+| Command              | Description                                                   | Input formats  | Output formats  |
+| -------------------- | ------------------------------------------------------------- | -------------- | --------------- |
+| lin install-menu     | Installs app context menu (right click in Dolphin)   | No input files | No output files |
+| lin uninstall-menu   | Uninstalls app context menu (right click in Dolphin) | No input files | No output files |
 
 
 ### App configuration

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A powerful Python-based CLI and GUI tool for converting, compressing, and manipu
   - [Usage](#usage)
     - [CLI - Command line interface](#cli---command-line-interface)
     - [GUI - Graphical user interface](#gui---graphical-user-interface)
-    - [Windows Context Menu (Windows OS only)](#windows-context-menu-windows-os-only)
+    - [Context Menu (Windows / KDE Linux)](#context-menu-windows--kde-linux)
   - [Why use File Conversor?](#why-use-file-conversor)
   - [Features](#features)
   - [External dependencies](#external-dependencies)
@@ -40,9 +40,9 @@ Run ``file_conversor -h`` to explore all available commands and options.
 
 Run ``file_conversor_gui`` to launch the GUI application or double click the Windows Shortcut.
 
-### Windows Context Menu (Windows OS only)
+### Context Menu (Windows / KDE Linux)
 
-1. Right click a file in Windows Explorer
+1. Right click a file in your file explorer
 2. Choose an action from "File Conversor" menu
   
 <img src="./assets/ctx_menu.jpg" width="600px">
@@ -80,6 +80,7 @@ Run ``file_conversor_gui`` to launch the GUI application or double click the Win
 
 - **Multiple Interfaces**  
   - **Windows Explorer integration**: right-click files for quick actions
+  - **KDE Linux integration**: right-click files in Dolphin for quick actions
   - CLI for scripting and automation  
 
 *For full feature set, check* [`FEATURE_SET.md`](FEATURE_SET.md)

--- a/src/file_conversor/backend/abstract_backend.py
+++ b/src/file_conversor/backend/abstract_backend.py
@@ -87,15 +87,21 @@ class AbstractBackend:
                 continue
 
             # supported pkg manager found, proceed to check for dependencies
-            missing_deps = self._check_missing_deps(pkg_mgr)
+            missing_deps = pkg_mgr.get_missing_dependencies()
             if not missing_deps:
+                # this pkg manager sees no missing deps: nothing to do
                 continue
 
-            # install package manager, if not present already
-            self._check_pkg_manager_installed(pkg_mgr)
+            # check if the pkg manager itself is installed before trying to use it
+            if not pkg_mgr.get_pkg_manager_installed():
+                # pkg manager not available, skip and let another handle it
+                continue
 
             # install missing dependencies
             self._install_missing_deps(pkg_mgr, missing_deps)
+            # re-check: if deps are now satisfied, stop trying other pkg managers
+            if not pkg_mgr.get_missing_dependencies():
+                break
 
     def _check_missing_deps(self, pkg_mgr: AbstractPackageManager) -> set[str]:
         """

--- a/src/file_conversor/backend/image/_gifsicle_backend.py
+++ b/src/file_conversor/backend/image/_gifsicle_backend.py
@@ -11,7 +11,7 @@ from typing import Any
 # user-provided imports
 from file_conversor.backend.abstract_backend import AbstractBackend
 from file_conversor.config import LOG, Environment, get_translation
-from file_conversor.dependency import BrewPackageManager, ScoopPackageManager
+from file_conversor.dependency import AptPackageManager, BrewPackageManager, DnfPackageManager, ScoopPackageManager
 
 
 _ = get_translation()
@@ -52,6 +52,12 @@ class GifSicleBackend(AbstractBackend):  # pyright: ignore[reportUnusedClass]
                     "gifsicle": "gifsicle"
                 }),
                 BrewPackageManager({
+                    "gifsicle": "gifsicle"
+                }),
+                DnfPackageManager({
+                    "gifsicle": "gifsicle"
+                }),
+                AptPackageManager({
                     "gifsicle": "gifsicle"
                 }),
             },

--- a/src/file_conversor/backend/image/_mozjpeg_backend.py
+++ b/src/file_conversor/backend/image/_mozjpeg_backend.py
@@ -10,7 +10,7 @@ from typing import Any
 # user-provided imports
 from file_conversor.backend.abstract_backend import AbstractBackend
 from file_conversor.config import LOG, Environment, get_translation
-from file_conversor.dependency import BrewPackageManager, ScoopPackageManager
+from file_conversor.dependency import AptPackageManager, BrewPackageManager, DnfPackageManager, ScoopPackageManager
 
 
 _ = get_translation()
@@ -53,6 +53,12 @@ class MozJPEGBackend(AbstractBackend):  # pyright: ignore[reportUnusedClass]
                 }),
                 BrewPackageManager({
                     "cjpeg": "mozjpeg"
+                }),
+                DnfPackageManager({
+                    "cjpeg": "libjpeg-turbo-utils"
+                }),
+                AptPackageManager({
+                    "cjpeg": "libjpeg-turbo-progs"
                 }),
             },
             install_answer=install_deps,

--- a/src/file_conversor/backend/image/_oxipng_backend.py
+++ b/src/file_conversor/backend/image/_oxipng_backend.py
@@ -13,7 +13,7 @@ from typing import Any
 # user-provided imports
 from file_conversor.backend.abstract_backend import AbstractBackend
 from file_conversor.config import LOG, Environment, get_translation
-from file_conversor.dependency import BrewPackageManager, ScoopPackageManager
+from file_conversor.dependency import AptPackageManager, BrewPackageManager, DnfPackageManager, ScoopPackageManager
 
 
 _ = get_translation()
@@ -53,6 +53,12 @@ class OxiPNGBackend(AbstractBackend):  # pyright: ignore[reportUnusedClass]
                     "oxipng": "oxipng"
                 }),
                 BrewPackageManager({
+                    "oxipng": "oxipng"
+                }),
+                DnfPackageManager({
+                    "oxipng": "oxipng"
+                }),
+                AptPackageManager({
                     "oxipng": "oxipng"
                 }),
             },

--- a/src/file_conversor/backend/image/compress_backend.py
+++ b/src/file_conversor/backend/image/compress_backend.py
@@ -61,12 +61,6 @@ class CompressBackend(AbstractBackend):
         :raises RuntimeError: if dependency is not found
         """
         super().__init__()
-        # get required dependencies
-        for mode in CompressBackend.SupportedInFormats:
-            mode.backend(
-                install_deps=install_deps,
-                verbose=verbose,
-            )
         self._install_deps = install_deps
         self._verbose = verbose
 

--- a/src/file_conversor/backend/lin_desktop_backend.py
+++ b/src/file_conversor/backend/lin_desktop_backend.py
@@ -1,0 +1,88 @@
+# src/file_conversor/backend/lin_desktop_backend.py
+
+"""
+Provides functionality for installing and removing KDE Dolphin service-menu
+``.desktop`` files and for triggering a KDE service-cache rebuild.
+"""
+
+import stat
+import subprocess
+
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+from file_conversor.backend.abstract_backend import AbstractBackend
+from file_conversor.config import LOG
+
+
+logger = LOG.getLogger(__name__)
+
+
+class LinDesktopBackend(AbstractBackend):
+    """Backend for managing KDE Dolphin service-menu ``.desktop`` files."""
+
+    EXTERNAL_DEPENDENCIES: set[str] = set()
+
+    def install(
+        self,
+        desktop_files: dict[Path, str],
+        progress_callback: Callable[[float], Any] = lambda p: p,
+    ) -> None:
+        """Write each ``{path: content}`` entry to disk, creating parent directories as needed."""
+        items = list(desktop_files.items())
+        total = len(items)
+        if not total:
+            progress_callback(100.0)
+            return
+        for i, (path, content) in enumerate(items):
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding="utf-8")
+            path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+            logger.info(f"Written: {path}")
+            progress_callback((i + 1) / total * 100.0)
+
+    def uninstall(
+        self,
+        paths: Iterable[Path],
+        progress_callback: Callable[[float], Any] = lambda p: p,
+    ) -> None:
+        """Delete each path if it exists."""
+        paths_list = list(paths)
+        total = len(paths_list)
+        if not total:
+            progress_callback(100.0)
+            return
+        for i, path in enumerate(paths_list):
+            if path.exists():
+                try:
+                    path.unlink()
+                    logger.info(f"Removed: {path}")
+                except PermissionError:
+                    logger.warning(f"Skipping (permission denied): {path}")
+            progress_callback((i + 1) / total * 100.0)
+
+    def rebuild_cache(
+        self,
+        progress_callback: Callable[[float], Any] = lambda p: p,
+    ) -> None:
+        """Run ``kbuildsycoca6`` (or ``kbuildsycoca5``) to refresh the KDE service cache."""
+        kbuildsycoca: Path | None = None
+        for candidate in ("kbuildsycoca6", "kbuildsycoca5"):
+            try:
+                kbuildsycoca = self.find_in_path(candidate)
+                break
+            except FileNotFoundError:
+                continue
+
+        if kbuildsycoca is None:
+            logger.warning("kbuildsycoca6/kbuildsycoca5 not found in PATH; KDE cache not rebuilt.")
+            progress_callback(100.0)
+            return
+
+        subprocess.run([str(kbuildsycoca), "--noincremental"], check=True)  # noqa: S603
+        progress_callback(100.0)
+
+
+__all__ = [
+    "LinDesktopBackend",
+]

--- a/src/file_conversor/cli/__init__.py
+++ b/src/file_conversor/cli/__init__.py
@@ -24,6 +24,7 @@ from file_conversor.cli.pipeline import PipelineTyperGroup
 from file_conversor.cli.ppt import PptTyperGroup
 from file_conversor.cli.text import TextTyperGroup
 from file_conversor.cli.video import VideoTyperGroup
+from file_conversor.cli.lin import LinTyperGroup
 from file_conversor.cli.win import WinTyperGroup
 from file_conversor.cli.xls import XlsTyperGroup
 
@@ -116,6 +117,7 @@ class AppTyperGroup(AbstractTyperGroup):
         TEXT = "text"
         VIDEO = "video"
         WIN = "win"
+        LIN = "lin"
         XLS = "xls"
 
     # main callback to pass common options
@@ -218,6 +220,7 @@ class AppTyperGroup(AbstractTyperGroup):
 
             # UTILS and CONFIG
             WinTyperGroup(self.Commands.WIN.value, rich_help_panel=self.Panels.UTILS_CONFIG.value, hidden=System.Platform.get() != System.Platform.WINDOWS),
+            LinTyperGroup(self.Commands.LIN.value, rich_help_panel=self.Panels.UTILS_CONFIG.value, hidden=System.Platform.get() != System.Platform.LINUX),
             ConfigTyperGroup(self.Commands.CONFIG.value, rich_help_panel=self.Panels.UTILS_CONFIG.value),
             PipelineTyperGroup(self.Commands.PIPELINE.value, rich_help_panel=self.Panels.UTILS_CONFIG.value),
         )

--- a/src/file_conversor/cli/image/compress_cli.py
+++ b/src/file_conversor/cli/image/compress_cli.py
@@ -36,6 +36,7 @@ class ImageCompressCLI(AbstractTyperCommand):
                     description="Compress",
                     args=[self.GROUP_NAME, self.COMMAND_NAME],
                     icon=icons_folder / 'compress.ico',
+                    keep_terminal_open=True,
                 ),
             ])
 

--- a/src/file_conversor/cli/image/enhance_cli.py
+++ b/src/file_conversor/cli/image/enhance_cli.py
@@ -37,6 +37,7 @@ class ImageEnhanceCLI(AbstractTyperCommand):
                     description="Enhance",
                     args=[self.GROUP_NAME, self.COMMAND_NAME],
                     icon=icons_folder / "color.ico",
+                    keep_terminal_open=True,
                 ),
             ])
 

--- a/src/file_conversor/cli/image/info_cli.py
+++ b/src/file_conversor/cli/image/info_cli.py
@@ -31,6 +31,7 @@ class ImageInfoCLI(AbstractTyperCommand):
                     description="Get Info",
                     args=[self.GROUP_NAME, self.COMMAND_NAME],
                     icon=icons_folder / "info.ico",
+                    keep_terminal_open=True,
                 ),
             ])
 

--- a/src/file_conversor/cli/image/resize_cli.py
+++ b/src/file_conversor/cli/image/resize_cli.py
@@ -32,6 +32,7 @@ class ImageResizeCLI(AbstractTyperCommand):
                     description="Resize",
                     args=[self.GROUP_NAME, self.COMMAND_NAME],
                     icon=icons_folder / "resize.ico",
+                    keep_terminal_open=True,
                 ),
             ])
 

--- a/src/file_conversor/cli/lin/__init__.py
+++ b/src/file_conversor/cli/lin/__init__.py
@@ -1,0 +1,41 @@
+# src/file_conversor/cli/lin/__init__.py
+
+from enum import Enum
+
+from file_conversor.cli._utils.abstract_typer_group import AbstractTyperGroup
+from file_conversor.cli.lin.install_menu_cli import LinInstallMenuCLI
+from file_conversor.cli.lin.uninstall_menu_cli import LinUninstallMenuCLI
+from file_conversor.config.locale import get_translation
+
+
+_ = get_translation()
+
+
+class LinTyperGroup(AbstractTyperGroup):
+    class Panels(Enum):
+        CONTEXT_MENU = _("Context menu")
+
+    class Commands(Enum):
+        INSTALL_MENU = "install-menu"
+        UNINSTALL_MENU = "uninstall-menu"
+
+    def __init__(self, group_name: str, rich_help_panel: str, hidden: bool) -> None:
+        super().__init__(
+            rich_help_panel=rich_help_panel,
+            group_name=group_name,
+            help=_("Linux OS commands (for Linux ONLY)"),
+            hidden=hidden,
+        )
+
+        self.add(
+            LinInstallMenuCLI(
+                group_name=group_name,
+                command_name=self.Commands.INSTALL_MENU.value,
+                rich_help_panel=self.Panels.CONTEXT_MENU.value,
+            ),
+            LinUninstallMenuCLI(
+                group_name=group_name,
+                command_name=self.Commands.UNINSTALL_MENU.value,
+                rich_help_panel=self.Panels.CONTEXT_MENU.value,
+            ),
+        )

--- a/src/file_conversor/cli/lin/install_menu_cli.py
+++ b/src/file_conversor/cli/lin/install_menu_cli.py
@@ -1,0 +1,51 @@
+# src/file_conversor/cli/lin/install_menu_cli.py
+
+from typing import Annotated
+
+import typer
+
+from file_conversor.cli._utils import AbstractTyperCommand, RichProgressBar
+from file_conversor.command.lin import LinInstallMenuCommand
+from file_conversor.config import LOG, STATE, get_translation
+
+
+_ = get_translation()
+logger = LOG.getLogger(__name__)
+
+
+class LinInstallMenuCLI(AbstractTyperCommand):
+    def __init__(self, group_name: str, command_name: str, rich_help_panel: str | None) -> None:
+        super().__init__(
+            rich_help_panel=rich_help_panel,
+            group_name=group_name,
+            command_name=command_name,
+            function=self.install_menu,
+            help=f"""
+    {_('Installs app context menu (right click in Dolphin file manager).')}
+""",
+            epilog=f"""
+    **{_('Examples')}:**
+
+    - `file_conversor {group_name} {command_name}`
+""")
+
+    def install_menu(
+        self,
+        rebuild_cache: Annotated[bool, typer.Option(
+            "--rebuild-cache", "-rc",
+            help=_("Rebuild KDE service cache after install (to make context menu effective immediately). Defaults to False."),
+            is_flag=True,
+        )] = False,
+    ):
+        with RichProgressBar(STATE.progress.enabled) as progress_bar:
+            task = progress_bar.add_task(_("Installing context menu:"))
+            command = LinInstallMenuCommand(
+                rebuild_cache=rebuild_cache,
+                progress_callback=task.update,
+            )
+            command.execute()
+
+
+__all__ = [
+    "LinInstallMenuCLI",
+]

--- a/src/file_conversor/cli/lin/uninstall_menu_cli.py
+++ b/src/file_conversor/cli/lin/uninstall_menu_cli.py
@@ -1,0 +1,39 @@
+# src/file_conversor/cli/lin/uninstall_menu_cli.py
+
+from file_conversor.cli._utils import AbstractTyperCommand, RichProgressBar
+from file_conversor.command.lin import LinUninstallMenuCommand
+from file_conversor.config import LOG, STATE, get_translation
+
+
+_ = get_translation()
+logger = LOG.getLogger(__name__)
+
+
+class LinUninstallMenuCLI(AbstractTyperCommand):
+    def __init__(self, group_name: str, command_name: str, rich_help_panel: str | None) -> None:
+        super().__init__(
+            rich_help_panel=rich_help_panel,
+            group_name=group_name,
+            command_name=command_name,
+            function=self.uninstall_menu,
+            help=f"""
+    {_('Uninstalls app context menu (right click in Dolphin file manager).')}
+""",
+            epilog=f"""
+    **{_('Examples')}:**
+
+    - `file_conversor {group_name} {command_name}`
+""")
+
+    def uninstall_menu(self):
+        with RichProgressBar(STATE.progress.enabled) as progress_bar:
+            task = progress_bar.add_task(_("Uninstalling context menu:"))
+            command = LinUninstallMenuCommand(
+                progress_callback=task.update,
+            )
+            command.execute()
+
+
+__all__ = [
+    "LinUninstallMenuCLI",
+]

--- a/src/file_conversor/cli/pdf/encrypt_cli.py
+++ b/src/file_conversor/cli/pdf/encrypt_cli.py
@@ -32,6 +32,7 @@ class PdfEncryptCLI(AbstractTyperCommand):
                     description="Encrypt",
                     args=[self.GROUP_NAME, self.COMMAND_NAME],
                     icon=icons_folder / "padlock_locked.ico",
+                    keep_terminal_open=True,
                 ),
             ])
 

--- a/src/file_conversor/cli/pdf/extract_cli.py
+++ b/src/file_conversor/cli/pdf/extract_cli.py
@@ -34,6 +34,7 @@ class PdfExtractCLI(AbstractTyperCommand):
                     description="Extract",
                     args=[self.GROUP_NAME, self.COMMAND_NAME],
                     icon=icons_folder / 'extract.ico',
+                    keep_terminal_open=True,
                 ),
             ])
 

--- a/src/file_conversor/cli/pdf/ocr_cli.py
+++ b/src/file_conversor/cli/pdf/ocr_cli.py
@@ -30,6 +30,7 @@ class PdfOcrCLI(AbstractTyperCommand):
                     description="OCR",
                     args=[self.GROUP_NAME, self.COMMAND_NAME],
                     icon=icons_folder / 'ocr.ico',
+                    keep_terminal_open=True,
                 ),
             ])
 

--- a/src/file_conversor/cli/video/enhance_cli.py
+++ b/src/file_conversor/cli/video/enhance_cli.py
@@ -53,6 +53,7 @@ class VideoEnhanceCLI(AbstractTyperCommand):
                     description="Enhance",
                     args=[self.GROUP_NAME, self.COMMAND_NAME],
                     icon=icons_folder / "color.ico",
+                    keep_terminal_open=True,
                 ),
             ])
 

--- a/src/file_conversor/cli/video/resize_cli.py
+++ b/src/file_conversor/cli/video/resize_cli.py
@@ -43,6 +43,7 @@ class VideoResizeCLI(AbstractTyperCommand):
                     description="Resize",
                     args=[self.GROUP_NAME, self.COMMAND_NAME],
                     icon=icons_folder / "resize.ico",
+                    keep_terminal_open=True,
                 ),
             ])
 

--- a/src/file_conversor/command/lin/__init__.py
+++ b/src/file_conversor/command/lin/__init__.py
@@ -1,0 +1,4 @@
+# src/file_conversor/command/lin/__init__.py
+
+from file_conversor.command.lin.install_menu_cmd import *
+from file_conversor.command.lin.uninstall_menu_cmd import *

--- a/src/file_conversor/command/lin/install_menu_cmd.py
+++ b/src/file_conversor/command/lin/install_menu_cmd.py
@@ -1,0 +1,81 @@
+# src/file_conversor/command/lin/install_menu_cmd.py
+
+from enum import StrEnum
+from typing import override
+
+from file_conversor.backend.lin_desktop_backend import LinDesktopBackend
+from file_conversor.command.abstract_cmd import AbstractCommand
+from file_conversor.config import LOG, get_translation
+from file_conversor.system.lin import LinuxContextMenu
+
+
+_ = get_translation()
+logger = LOG.getLogger(__name__)
+
+
+LinInstallMenuExternalDependencies: set[str] = set()
+
+
+class LinInstallMenuInFormats(StrEnum):
+    """Empty enum since this command is a system command, not a file-conversion command."""
+
+
+class LinInstallMenuOutFormats(StrEnum):
+    """Empty enum since this command is a system command, not a file-conversion command."""
+
+
+class LinInstallMenuCommand(AbstractCommand[LinInstallMenuInFormats, LinInstallMenuOutFormats]):
+    rebuild_cache: bool
+
+    @classmethod
+    @override
+    def _external_dependencies(cls):
+        return LinInstallMenuExternalDependencies
+
+    @classmethod
+    @override
+    def _supported_in_formats(cls):
+        return LinInstallMenuInFormats
+
+    @classmethod
+    @override
+    def _supported_out_formats(cls):
+        return LinInstallMenuOutFormats
+
+    @override
+    def execute(self) -> None:
+        step_completion = 40.0  # percentage allocated to each uninstall/install step (80% total)
+
+        backend = LinDesktopBackend()
+        ctx_menu = LinuxContextMenu.get_instance()
+
+        logger.info(f"{_('Uninstalling app context menu in Dolphin')} ...")
+        backend.uninstall(
+            ctx_menu.get_desktop_uninstall_paths(),
+            progress_callback=lambda p: self.progress_callback(p * step_completion / 100.0),
+        )
+
+        logger.info(f"{_('Installing app context menu in Dolphin')} ...")
+        backend.install(
+            ctx_menu.get_desktop_files(),
+            progress_callback=lambda p: self.progress_callback(step_completion + p * step_completion / 100.0),
+        )
+
+        if self.rebuild_cache:
+            logger.info(f"{_('Rebuilding KDE service cache')} ...")
+            backend.rebuild_cache(
+                progress_callback=lambda p: self.progress_callback(80.0 + p * 20.0 / 100.0),
+            )
+        else:
+            logger.warning(_("Run 'kbuildsycoca6' or log off from KDE to make context menu changes effective immediately."))
+
+        logger.info(f"{_('Context Menu Install')}: [bold green]{_('SUCCESS')}[/].")
+        self.progress_callback(100.0)
+
+
+__all__ = [
+    "LinInstallMenuExternalDependencies",
+    "LinInstallMenuInFormats",
+    "LinInstallMenuOutFormats",
+    "LinInstallMenuCommand",
+]

--- a/src/file_conversor/command/lin/uninstall_menu_cmd.py
+++ b/src/file_conversor/command/lin/uninstall_menu_cmd.py
@@ -1,0 +1,62 @@
+# src/file_conversor/command/lin/uninstall_menu_cmd.py
+
+from enum import StrEnum
+from typing import override
+
+from file_conversor.backend.lin_desktop_backend import LinDesktopBackend
+from file_conversor.command.abstract_cmd import AbstractCommand
+from file_conversor.config import LOG, get_translation
+from file_conversor.system.lin import LinuxContextMenu
+
+
+_ = get_translation()
+logger = LOG.getLogger(__name__)
+
+
+LinUninstallMenuExternalDependencies: set[str] = set()
+
+
+class LinUninstallMenuInFormats(StrEnum):
+    """Empty enum since this command is a system command, not a file-conversion command."""
+
+
+class LinUninstallMenuOutFormats(StrEnum):
+    """Empty enum since this command is a system command, not a file-conversion command."""
+
+
+class LinUninstallMenuCommand(AbstractCommand[LinUninstallMenuInFormats, LinUninstallMenuOutFormats]):
+    @classmethod
+    @override
+    def _external_dependencies(cls):
+        return LinUninstallMenuExternalDependencies
+
+    @classmethod
+    @override
+    def _supported_in_formats(cls):
+        return LinUninstallMenuInFormats
+
+    @classmethod
+    @override
+    def _supported_out_formats(cls):
+        return LinUninstallMenuOutFormats
+
+    @override
+    def execute(self) -> None:
+        backend = LinDesktopBackend()
+        ctx_menu = LinuxContextMenu.get_instance()
+
+        logger.info(f"{_('Removing app context menu from Dolphin')} ...")
+        backend.uninstall(
+            ctx_menu.get_desktop_uninstall_paths(),
+            progress_callback=self.progress_callback,
+        )
+
+        logger.info(f"{_('Context Menu Uninstall')}: [bold green]{_('SUCCESS')}[/].")
+
+
+__all__ = [
+    "LinUninstallMenuExternalDependencies",
+    "LinUninstallMenuInFormats",
+    "LinUninstallMenuOutFormats",
+    "LinUninstallMenuCommand",
+]

--- a/src/file_conversor/dependency/__init__.py
+++ b/src/file_conversor/dependency/__init__.py
@@ -3,5 +3,7 @@
 """Module for package managers that provide external dependencies"""
 
 from file_conversor.dependency.abstract_pkg_manager import *
+from file_conversor.dependency.apt_pkg_manager import *
 from file_conversor.dependency.brew_pkg_manager import *
+from file_conversor.dependency.dnf_pkg_manager import *
 from file_conversor.dependency.scoop_pkg_manager import *

--- a/src/file_conversor/dependency/apt_pkg_manager.py
+++ b/src/file_conversor/dependency/apt_pkg_manager.py
@@ -1,0 +1,56 @@
+# src/file_conversor/dependency/apt_pkg_manager.py
+
+import shutil
+
+from pathlib import Path
+from typing import override
+
+from file_conversor.config.locale import get_translation
+from file_conversor.dependency.abstract_pkg_manager import AbstractPackageManager
+from file_conversor.system import AbstractSystem, System
+
+
+_ = get_translation()
+
+
+class AptPackageManager(AbstractPackageManager):
+    """Package manager for Debian / Ubuntu / Mint (apt)."""
+
+    def __init__(
+        self,
+        dependencies: dict[str, str],
+        env: list[str | Path] | None = None,
+    ) -> None:
+        super().__init__(dependencies=dependencies, env=env)
+
+    @override
+    def _get_pkg_manager_installed(self) -> str | None:
+        return shutil.which("apt-get")
+
+    @override
+    def _get_supported_oses(self) -> set[AbstractSystem.Platform]:
+        return {System.Platform.LINUX}
+
+    @override
+    def get_missing_dependencies(self) -> set[str]:
+        # Skip entirely if apt-get is not available on this system
+        if not self._get_pkg_manager_installed():
+            return set()
+        return super().get_missing_dependencies()
+
+    @override
+    def _get_cmd_install_pkg_manager(self) -> list[str]:
+        raise RuntimeError("apt-get is a system package manager and cannot be installed by this tool.")
+
+    @override
+    def _post_install_pkg_manager(self) -> None:
+        pass
+
+    @override
+    def _get_cmd_install_dep(self, dependency: str) -> list[str]:
+        return ["sudo", "apt-get", "install", "-y", dependency]
+
+
+__all__ = [
+    "AptPackageManager",
+]

--- a/src/file_conversor/dependency/dnf_pkg_manager.py
+++ b/src/file_conversor/dependency/dnf_pkg_manager.py
@@ -1,0 +1,57 @@
+# src/file_conversor/dependency/dnf_pkg_manager.py
+
+import shutil
+
+from pathlib import Path
+from typing import override
+
+from file_conversor.config.locale import get_translation
+from file_conversor.dependency.abstract_pkg_manager import AbstractPackageManager
+from file_conversor.system import AbstractSystem, System
+
+
+_ = get_translation()
+
+
+class DnfPackageManager(AbstractPackageManager):
+    """Package manager for Fedora / RHEL / CentOS (dnf/yum)."""
+
+    def __init__(
+        self,
+        dependencies: dict[str, str],
+        env: list[str | Path] | None = None,
+    ) -> None:
+        super().__init__(dependencies=dependencies, env=env)
+
+    @override
+    def _get_pkg_manager_installed(self) -> str | None:
+        return shutil.which("dnf") or shutil.which("yum")
+
+    @override
+    def _get_supported_oses(self) -> set[AbstractSystem.Platform]:
+        return {System.Platform.LINUX}
+
+    @override
+    def get_missing_dependencies(self) -> set[str]:
+        # Skip entirely if dnf/yum is not available on this system
+        if not self._get_pkg_manager_installed():
+            return set()
+        return super().get_missing_dependencies()
+
+    @override
+    def _get_cmd_install_pkg_manager(self) -> list[str]:
+        raise RuntimeError("dnf/yum is a system package manager and cannot be installed by this tool.")
+
+    @override
+    def _post_install_pkg_manager(self) -> None:
+        pass
+
+    @override
+    def _get_cmd_install_dep(self, dependency: str) -> list[str]:
+        pkg_mgr_bin = self._get_pkg_manager_installed() or "dnf"
+        return ["sudo", pkg_mgr_bin, "install", "-y", dependency]
+
+
+__all__ = [
+    "DnfPackageManager",
+]

--- a/src/file_conversor/system/context_menu.py
+++ b/src/file_conversor/system/context_menu.py
@@ -42,7 +42,7 @@ class ContextMenu:
 
     def _execute_callbacks(self) -> None:
         while self._register_callbacks:
-            callback = self._register_callbacks.pop()
+            callback = self._register_callbacks.pop(0)
             callback(self, self._icons_folder)
 
     def register_callback(self, function: 'ContextMenu.CallbackSignature') -> None:

--- a/src/file_conversor/system/lin/ctx_menu.py
+++ b/src/file_conversor/system/lin/ctx_menu.py
@@ -49,7 +49,12 @@ class LinuxContextMenu(ContextMenu):
                 return f'"{escaped}"'
             return escaped
 
-        return " ".join(_quote(arg) for arg in launcher)
+        exec_str = " ".join(_quote(arg) for arg in launcher)
+        if cmd.keep_terminal_open:
+            # TODO: Allow users to configure their preferred terminal emulator in the future.
+            # TODO: Add a GUI for this instead of a CLI prompt?
+            return f"konsole --hold -e {exec_str}"
+        return exec_str
 
     @override
     def add_extension(self, ext: str, commands: list[ContextMenuItem]) -> None:

--- a/src/file_conversor/system/lin/ctx_menu.py
+++ b/src/file_conversor/system/lin/ctx_menu.py
@@ -73,7 +73,6 @@ class LinuxContextMenu(ContextMenu):
             "Type=Service",
             "ServiceTypes=KonqPopupMenu/Plugin",
             "X-KDE-ServiceTypes=KonqPopupMenu/Plugin",
-            "X-KDE-AuthorizeAction=shell_access",
             "X-KDE-Priority=TopLevel",
             f"X-KDE-Submenu={self.MENU_NAME}",
             f"MimeType={mime};",

--- a/src/file_conversor/system/lin/ctx_menu.py
+++ b/src/file_conversor/system/lin/ctx_menu.py
@@ -33,7 +33,7 @@ class LinuxContextMenu(ContextMenu):
         import hashlib
 
         mime_clean = re.sub(r"[^A-Za-z0-9-]", "-", mime)
-        digest = hashlib.sha1(dedupe_key.encode("utf-8")).hexdigest()[:12]
+        digest = hashlib.sha1(dedupe_key.encode("utf-8")).hexdigest()[:12]  # noqa: S4790
         return f"fileconversor-{mime_clean}-{digest}"
 
     def _cmd_dedupe_key(self, cmd: ContextMenuItem) -> str:

--- a/src/file_conversor/system/lin/ctx_menu.py
+++ b/src/file_conversor/system/lin/ctx_menu.py
@@ -68,12 +68,18 @@ class LinuxContextMenu(ContextMenu):
         actions = self._entries[mime]
         action_ids = [self._action_id(mime, key) for key in actions]
 
+        app_icon = self._icons_folder / "icon.png"
+        if not app_icon.exists():
+            app_icon = self._icons_folder / "icon.ico"  # fallback just in case
+
         lines: list[str] = [
             "[Desktop Entry]",
             "Type=Service",
             "ServiceTypes=KonqPopupMenu/Plugin",
             "X-KDE-ServiceTypes=KonqPopupMenu/Plugin",
             "X-KDE-Priority=TopLevel",
+            f"Icon={app_icon}",
+            f"X-KDE-SubMenuIcon={app_icon}",  # fallback
             f"X-KDE-Submenu={self.MENU_NAME}",
             f"MimeType={mime};",
             f"Actions={';'.join(action_ids)};",

--- a/src/file_conversor/system/lin/ctx_menu.py
+++ b/src/file_conversor/system/lin/ctx_menu.py
@@ -128,9 +128,8 @@ class LinuxContextMenu(ContextMenu):
         for directory in dirs:
             if not directory.exists():
                 continue
-            result.extend(directory.glob(f"{self.APP_NAME}_*.desktop"))
+            result.extend(sorted(directory.glob(f"{self.APP_NAME}_*.desktop")))
         # Remove duplicate paths while preserving order.
-        # FIXME: It does fix the duplicates but it's actually not in order.
         return list(dict.fromkeys(result))
 
 

--- a/src/file_conversor/system/lin/ctx_menu.py
+++ b/src/file_conversor/system/lin/ctx_menu.py
@@ -1,17 +1,138 @@
 
 # src/file_conversor/system/lin/ctx_menu.py
 
+import mimetypes
+import re
+import sys
+
+from pathlib import Path
 from typing import override
 
+from file_conversor.config import Environment
 from file_conversor.system.context_menu import ContextMenu, ContextMenuItem
 
 
 class LinuxContextMenu(ContextMenu):
-    """Linux context menu handler."""
+    """Linux context menu handler (KDE Dolphin service menus)."""
+
+    APP_NAME = "file_conversor"
+    MENU_NAME = "File Conversor"
+
+    def __init__(self) -> None:
+        super().__init__()
+        # mime_type -> {dedupe_key: ContextMenuItem}
+        self._entries: dict[str, dict[str, ContextMenuItem]] = {}
+
+    def _ext_to_mime(self, ext: str) -> str:
+        """Convert a file extension (e.g. '.jpg') to its MIME type."""
+        mime, _ = mimetypes.guess_type(f"file{ext}")
+        return mime or f"application/x-{ext.lstrip('.').lower()}"
+
+    def _action_id(self, mime: str, dedupe_key: str) -> str:
+        """Build a unique, KDE-safe action identifier."""
+        import hashlib
+
+        mime_clean = re.sub(r"[^A-Za-z0-9-]", "-", mime)
+        digest = hashlib.sha1(dedupe_key.encode("utf-8")).hexdigest()[:12]
+        return f"fileconversor-{mime_clean}-{digest}"
+
+    def _cmd_dedupe_key(self, cmd: ContextMenuItem) -> str:
+        icon = str(cmd.icon) if cmd.icon else ""
+        args = "\x1f".join(cmd.args)
+        return f"{cmd.name}\x1e{cmd.description}\x1e{args}\x1e{icon}\x1e{int(cmd.keep_terminal_open)}"
+
+    def _build_exec(self, cmd: ContextMenuItem) -> str:
+        launcher = [sys.executable, "-m", Environment.get_app_name(), *cmd.args, "%F"]
+
+        def _quote(arg: str) -> str:
+            escaped = arg.replace("\\", "\\\\").replace('"', '\\"')
+            if any(ch.isspace() for ch in escaped) or any(ch in escaped for ch in ('"', "'", "\\")):
+                return f'"{escaped}"'
+            return escaped
+
+        return " ".join(_quote(arg) for arg in launcher)
 
     @override
     def add_extension(self, ext: str, commands: list[ContextMenuItem]) -> None:
-        """TODO: implement context menu for linux (not trivial, since it depends on the desktop environment)."""
+        """Register Dolphin context-menu actions for files with the given extension."""
+        mime = self._ext_to_mime(ext)
+        if mime not in self._entries:
+            self._entries[mime] = {}
+        actions = self._entries[mime]
+        for cmd in commands:
+            dedupe_key = self._cmd_dedupe_key(cmd)
+            actions[dedupe_key] = cmd
+
+    def _build_desktop_content(self, mime: str) -> str:
+        """Render the .desktop file content for a single MIME type."""
+        actions = self._entries[mime]
+        action_ids = [self._action_id(mime, key) for key in actions]
+
+        lines: list[str] = [
+            "[Desktop Entry]",
+            "Type=Service",
+            "ServiceTypes=KonqPopupMenu/Plugin",
+            "X-KDE-ServiceTypes=KonqPopupMenu/Plugin",
+            "X-KDE-AuthorizeAction=shell_access",
+            "X-KDE-Priority=TopLevel",
+            f"X-KDE-Submenu={self.MENU_NAME}",
+            f"MimeType={mime};",
+            f"Actions={';'.join(action_ids)};",
+            "",
+        ]
+
+        for key, cmd in actions.items():
+            action_id = self._action_id(mime, key)
+            exec_str = self._build_exec(cmd)
+            lines += [
+                f"[Desktop Action {action_id}]",
+                f"Name={cmd.description}",
+                f"Icon={cmd.icon}" if cmd.icon else "Icon=",
+                f"Exec={exec_str}",
+                "",
+            ]
+
+        return "\n".join(lines)
+
+    def get_desktop_install_dir(self) -> Path:
+        """Return the KDE service-menus directory appropriate for the current privilege level."""
+        from file_conversor.system.lin.linux_system import LinuxSystem
+
+        if LinuxSystem.is_admin():
+            if Path("/usr/share/kio/servicemenus").exists():
+                return Path("/usr/share/kio/servicemenus")
+            return Path("/usr/share/kservices5/ServiceMenus")
+        if (Path.home() / ".local" / "share" / "kio" / "servicemenus").exists():
+            return Path.home() / ".local" / "share" / "kio" / "servicemenus"
+        return Path.home() / ".local" / "share" / "kservices5" / "ServiceMenus"
+
+    def get_desktop_files(self) -> dict[Path, str]:
+        """Execute registered callbacks and return ``{install_path: content}`` for every extension."""
+        self._execute_callbacks()
+        install_dir = self.get_desktop_install_dir()
+        result: dict[Path, str] = {}
+        for mime in self._entries:
+            clean = mime.replace("/", "_").replace("-", "_").replace("+", "_").lower()
+            filename = f"{self.APP_NAME}_{clean}.desktop"
+            result[install_dir / filename] = self._build_desktop_content(mime)
+        return result
+
+    def get_desktop_uninstall_paths(self) -> list[Path]:
+        """Return paths of all currently installed desktop files belonging to this app."""
+        dirs = [
+            Path.home() / ".local" / "share" / "kio" / "servicemenus",
+            Path("/usr/share/kio/servicemenus"),
+            Path.home() / ".local" / "share" / "kservices5" / "ServiceMenus",
+            Path("/usr/share/kservices5/ServiceMenus"),
+        ]
+        result: list[Path] = []
+        for directory in dirs:
+            if not directory.exists():
+                continue
+            result.extend(directory.glob(f"{self.APP_NAME}_*.desktop"))
+        # Remove duplicate paths while preserving order.
+        # FIXME: It does fix the duplicates but it's actually not in order.
+        return list(dict.fromkeys(result))
 
 
 __all__ = [

--- a/src/file_conversor/system/lin/ctx_menu.py
+++ b/src/file_conversor/system/lin/ctx_menu.py
@@ -28,13 +28,12 @@ class LinuxContextMenu(ContextMenu):
         mime, _ = mimetypes.guess_type(f"file{ext}")
         return mime or f"application/x-{ext.lstrip('.').lower()}"
 
-    def _action_id(self, mime: str, dedupe_key: str) -> str:
-        """Build a unique, KDE-safe action identifier."""
-        import hashlib
-
-        mime_clean = re.sub(r"[^A-Za-z0-9-]", "-", mime)
-        digest = hashlib.sha1(dedupe_key.encode("utf-8")).hexdigest()[:12]  # noqa: S4790
-        return f"fileconversor-{mime_clean}-{digest}"
+    def _action_id(self, mime: str, index: int, cmd: ContextMenuItem) -> str:
+        """Build a stable, KDE-safe action identifier."""
+        mime_clean = re.sub(r"[^A-Za-z0-9-]", "-", mime).strip("-")
+        name_slug = re.sub(r"[^A-Za-z0-9-]", "-", cmd.description.casefold()).strip("-")
+        name_slug = re.sub(r"-+", "-", name_slug) or "action"
+        return f"fileconversor-{mime_clean}-{index:02d}-{name_slug}"
 
     def _cmd_dedupe_key(self, cmd: ContextMenuItem) -> str:
         icon = str(cmd.icon) if cmd.icon else ""
@@ -66,7 +65,18 @@ class LinuxContextMenu(ContextMenu):
     def _build_desktop_content(self, mime: str) -> str:
         """Render the .desktop file content for a single MIME type."""
         actions = self._entries[mime]
-        action_ids = [self._action_id(mime, key) for key in actions]
+        ordered_actions = sorted(
+            actions.items(),
+            key=lambda item: (
+                item[1].description.casefold(),
+                item[1].name.casefold(),
+                item[0],
+            ),
+        )
+        action_ids = [
+            self._action_id(mime, index, cmd)
+            for index, (_, cmd) in enumerate(ordered_actions, start=1)
+        ]
 
         app_icon = self._icons_folder / "icon.png"
         if not app_icon.exists():
@@ -86,8 +96,8 @@ class LinuxContextMenu(ContextMenu):
             "",
         ]
 
-        for key, cmd in actions.items():
-            action_id = self._action_id(mime, key)
+        for index, (_, cmd) in enumerate(ordered_actions, start=1):
+            action_id = self._action_id(mime, index, cmd)
             exec_str = self._build_exec(cmd)
             lines += [
                 f"[Desktop Action {action_id}]",

--- a/src/file_conversor/tests/backend/test_lin_desktop_backend.py
+++ b/src/file_conversor/tests/backend/test_lin_desktop_backend.py
@@ -1,0 +1,17 @@
+import stat
+
+from pathlib import Path
+
+from file_conversor.backend.lin_desktop_backend import LinDesktopBackend
+
+
+class TestLinDesktopBackend:
+    def test_install_marks_desktop_file_executable(self, tmp_path: Path):
+        backend = LinDesktopBackend()
+        desktop_file = tmp_path / "test.desktop"
+
+        backend.install({desktop_file: "[Desktop Entry]\nType=Service\n"})
+
+        file_mode = desktop_file.stat().st_mode
+        assert desktop_file.exists()
+        assert file_mode & stat.S_IXUSR

--- a/src/file_conversor/tests/system/lin/test_lin_ctx_menu.py
+++ b/src/file_conversor/tests/system/lin/test_lin_ctx_menu.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from file_conversor.system import ContextMenu, ContextMenuItem
+from file_conversor.system.lin.ctx_menu import LinuxContextMenu
+
+
+class TestLinuxContextMenu:
+    def setup_method(self):
+        LinuxContextMenu._instance = None
+
+    def test_register_callbacks_groups_by_mime_and_dedupes(self):
+        menu = LinuxContextMenu.get_instance()
+
+        ctx_item = ContextMenuItem(
+            name="to_png",
+            description="To PNG",
+            args=["image", "convert", "-f", "png"],
+            icon=None,
+        )
+
+        def register(ctx_menu: ContextMenu, _icons_path: Path) -> None:
+            ctx_menu.add_extension(".jpg", [ctx_item])
+            ctx_menu.add_extension(".jpeg", [ctx_item])
+
+        menu.register_callback(register)
+        desktop_files = menu.get_desktop_files()
+
+        assert len(desktop_files) == 1
+        content = next(iter(desktop_files.values()))
+        assert "X-KDE-Submenu=File Conversor" in content
+        assert "MimeType=image/jpeg;" in content
+        assert content.count("Name=To PNG") == 1
+        assert "Exec=" in content
+        assert f'{Path(menu._exe_path).parent / Path(menu._exe_path).name}' not in content
+        assert f'{Path(__import__("sys").executable)} -m file_conversor image convert -f png %F' in content


### PR DESCRIPTION
Basic support for linux context menu, allowing users to install and uninstall context menu entries for the application via the CLI. It adds new backend, command, and CLI modules to handle .desktop file management and KDE service cache rebuilding, as well as corresponding tests to ensure correct behavior. The main CLI now conditionally exposes these Linux-specific commands only on Linux systems.
Only supporting dolphin (kde) atm. Works but still needs some work!

<img width="50%" height="491" alt="image" src="https://github.com/user-attachments/assets/a579e6de-3059-4f17-88f2-c2e14f562048" />

**Testing**

* Added tests for the backend to ensure `.desktop` files are installed with executable permissions.
* Added tests for the context menu logic, verifying grouping, deduplication, and correct `.desktop` file content generation *

**TODO:**
- [x] update the readme accordingly
- [x] move the actions in the right order
- [x] update the context menu icon ; EDIT: I think that's impossible. It always uses the first action icon.
- [x] check support for other KDE file managers ; EDIT: I tried Krusader, doesn't work, don't care cause there aren't many file manager alternatives for KDE anyway, let's focus on GNOME instead.
- [ ] edit some code to make it easier to adapt on gnome because it will be a mess later otherwise (I don't like gnome so i'm not motivated)
- [x] Fix resize
- [x] Fix enhance
- [x] Fix get info
- [x] Fix compress
